### PR TITLE
List perms

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ I wrote this to help in my day to day working in GCP. A lot of the time I am doi
 
 ## Features
 Compares and analyzes GCP IAM roles. Currently supports 2 role comparisons to find:
-- The differences between the two. 
+- The differences between the two.
 - Which permissions the two roles share.
-- Or both! Can output differences and shared permissions in the same flow.
+- Lists permissions for a given role or list of roles.
+- Can output differences and shared permissions in the same flow.
 
 In order to determine what permissions a role has we need some type of role -> permission lookup. Luckily, I already have that via a different project [gcp_iam_update_bot](https://github.com/jdyke/gcp_iam_update_bot) which keeps an up to date list of ALL GCP IAM roles and their permissions (refreshes every 12 hours).
 
@@ -22,7 +23,7 @@ Otherwise you can always re-update your local roles database via `./gcp-iam-anal
 
 ```sh
 ./gcp-iam-analyzer.py --help
-usage: gcp-iam-analyzer.py [-h] [-d ROLES [ROLES ...]] [-s ROLES [ROLES ...]] [-a ROLES [ROLES ...]] [-r]
+usage: gcp-iam-analyzer.py [-h] [-d ROLES [ROLES ...]] [-s ROLES [ROLES ...]] [-a ROLES [ROLES ...]] [-l ROLES [ROLES ...]] [-r]
 
 Compares GCP IAM roles and outputs analysis.
 
@@ -33,13 +34,15 @@ optional arguments:
   -s ROLES [ROLES ...], --shared ROLES [ROLES ...]
                         Compares roles and outputs the shared permissions.
   -a ROLES [ROLES ...], --all ROLES [ROLES ...]
-                        Compares roles and outputs the differences and the shared permissinos.
+                        Compares roles and outputs the differences and the shared permissins.
+  -l ROLES [ROLES ...], --list ROLES [ROLES ...]
+                        Lists permissions for role(s).
   -r, --refresh         Refreshes the local "roles" folder.
 ```
 
 
-## Example 
-Let's say we have a user in GCP that has the `vpcaccess.admin` role and you want to find out how many permissions they would "lose" if they were assigned the `vpcaccess.viewer` role. 
+## Example
+Let's say we have a user in GCP that has the `vpcaccess.admin` role and you want to find out how many permissions they would "lose" if they were assigned the `vpcaccess.viewer` role.
 
 ```sh
 ./gcp-iam-analyzer.py -d vpcaccess.viewer vpcaccess.admin
@@ -58,7 +61,7 @@ The above output shows that by assigning the `vpcaccess.viewer` role and removin
 'vpcaccess.connectors.delete',
 'vpcaccess.connectors.use'
  ```
- 
+
  ## Feedback
- 
+
  Feel free to open an issue if you encounter a bug or reach out via twitter [@jasonadyke](https://twitter.com/jasonadyke)

--- a/gcp-iam-analyzer.py
+++ b/gcp-iam-analyzer.py
@@ -32,15 +32,18 @@ def inputs(args):
             perms_shared(shared_roles)
     if args["all"]:
         if len(args["all"]) != 2:
-            logging.error("Need 2 roles to compare both different and shared permissions..")
+            logging.error(
+                "Need 2 roles to compare both different and shared permissions..")
             logging.error("Please rerun with 2 roles. Exiting. \n")
             sys.exit(1)
         else:
-            logging.info("All flag set, will output diff and shared permissions. \n")
+            logging.info(
+                "All flag set, will output diff and shared permissions. \n")
             all_roles = args["all"]
             perms_all(all_roles)
     if args["list"]:
-        logging.info("List flag set, will output permissions for supplied role(s). \n")
+        logging.info(
+            "List flag set, will output permissions for supplied role(s). \n")
         list_roles = args["list"]
         list_perms(list_roles)
 
@@ -109,7 +112,8 @@ def perms_shared(shared_roles):
 
     # Compare the two lists and display similarities
     shared_perms = set(role_one_perms) & set(role_two_perms)
-    print(f"# The shared permissions between {role_one} and {role_two} are: \n")
+    print(
+        f"# The shared permissions between {role_one} and {role_two} are: \n")
     pprint(shared_perms)
 
 
@@ -135,7 +139,8 @@ def roles_refresh():
     try:
         # Get the latest release tag URL
         logging.info("Downloading latest GCP IAM roles dataset... \n")
-        response = requests.get("https://api.github.com/repos/jdyke/gcp_iam_update_bot/releases/latest")
+        response = requests.get(
+            "https://api.github.com/repos/jdyke/gcp_iam_update_bot/releases/latest")
 
         # Construct the tarball download URL
         tarball_name = response.json()["tag_name"]
@@ -232,25 +237,33 @@ def members(tarball):
 if __name__ == "__main__":
     # Configure logging format
     # TODO: Update to info logging
-    logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.ERROR)
+    logging.basicConfig(format='%(levelname)s:%(message)s',
+                        level=logging.ERROR)
 
     # Configure arguments
-    parser = argparse.ArgumentParser(description="Compares GCP IAM roles and outputs analysis.")
-    parser.add_argument("-d", "--diff", nargs='+', metavar="ROLES", help="Compares roles and outputs the permissions difference.")
-    parser.add_argument("-s", "--shared", nargs='+', metavar="ROLES", help="Compares roles and outputs the shared permissions.")
-    parser.add_argument("-a", "--all", nargs='+', metavar="ROLES", help="Compares roles and outputs the differences and the shared permissins.")
-    parser.add_argument("-l", "--list", nargs='+', metavar="ROLES", help="Lists permissions for role(s).")
-    parser.add_argument("-r", "--refresh", help="Refreshes the local \"roles\" folder.", action='store_true')
+    parser = argparse.ArgumentParser(
+        description="Compares GCP IAM roles and outputs analysis.")
+    parser.add_argument("-d", "--diff", nargs='+', metavar="ROLES",
+                        help="Compares roles and outputs the permissions difference.")
+    parser.add_argument("-s", "--shared", nargs='+', metavar="ROLES",
+                        help="Compares roles and outputs the shared permissions.")
+    parser.add_argument("-a", "--all", nargs='+', metavar="ROLES",
+                        help="Compares roles and outputs the differences and the shared permissins.")
+    parser.add_argument("-l", "--list", nargs='+',
+                        metavar="ROLES", help="Lists permissions for role(s).")
+    parser.add_argument(
+        "-r", "--refresh", help="Refreshes the local \"roles\" folder.", action='store_true')
 
     args = vars(parser.parse_args())
 
     # Check if user wants to download or refresh roles folder.
     if args["refresh"]:
-        logging.info("Refresh flag set, will refresh local \"roles\" folder and continue..")
+        logging.info(
+            "Refresh flag set, will refresh local \"roles\" folder and continue..")
         roles_refresh()
 
     # Require at least one argument
-    if not args["diff"] and not args["shared"] and not args["all"] and not args["list"] :
+    if not args["diff"] and not args["shared"] and not args["all"] and not args["list"]:
         logging.error("One argument must be supplied.")
         sys.exit(0)
 
@@ -261,15 +274,19 @@ if __name__ == "__main__":
     if is_folder:
         logging.debug("Roles folder exists.. proceeding")
     else:
-        logging.error("\"roles\" folder does not exist. This is required for analysis.")
+        logging.error(
+            "\"roles\" folder does not exist. This is required for analysis.")
 
         # Ask user if they want to dl roles folder
-        refresh = input("Do you want to download the \"roles\" folder now? y/n \n")
+        refresh = input(
+            "Do you want to download the \"roles\" folder now? y/n \n")
         if refresh == "y":
             roles_refresh()
         elif refresh == "n":
-            logging.info("\"roles\" folder is required for analysis. Please execute with -r flag.")
+            logging.info(
+                "\"roles\" folder is required for analysis. Please execute with -r flag.")
         else:
-            logging.error(f"Invalid or no input found. Value entered: \"{refresh}\"")
+            logging.error(
+                f"Invalid or no input found. Value entered: \"{refresh}\"")
 
     inputs(args)

--- a/gcp-iam-analyzer.py
+++ b/gcp-iam-analyzer.py
@@ -39,6 +39,10 @@ def inputs(args):
             logging.info("All flag set, will output diff and shared permissions. \n")
             all_roles = args["all"]
             perms_all(all_roles)
+    if args["list"]:
+        logging.info("List flag set, will output permissions for supplied role(s). \n")
+        list_roles = args["list"]
+        list_perms(list_roles)
 
 
 def perms_diff(diff_roles):
@@ -57,7 +61,7 @@ def perms_diff(diff_roles):
 
     # Get the diff for role1
     role_one_diff = set(role_one_perms).difference(set(role_two_perms))
-    print(f"Role \"{role_one}\" differences:")
+    print(f"# Role \"{role_one}\" differences:")
     if not role_one_diff:
         role_one_diff = "N/A"
         pprint(role_one_diff)
@@ -68,7 +72,7 @@ def perms_diff(diff_roles):
     # Get the diff for role2
     role_two_diff = set(role_two_perms).difference(set(role_one_perms))
 
-    print(f"Role \"{role_two}\" differences:")
+    print(f"# Role \"{role_two}\" differences:")
     if not role_two_diff:
         role_two_diff = "N/A"
         pprint(role_two_diff)
@@ -85,7 +89,7 @@ def get_permissions(role_name):
     with open(f"./roles/{role_name}", "r") as role_file:
         role_file = json.load(role_file)
         role_perms = role_file["includedPermissions"]
-    
+
     return role_perms
 
 
@@ -105,7 +109,7 @@ def perms_shared(shared_roles):
 
     # Compare the two lists and display similarities
     shared_perms = set(role_one_perms) & set(role_two_perms)
-    print(f"The shared permissions between {role_one} and {role_two} are: \n")
+    print(f"# The shared permissions between {role_one} and {role_two} are: \n")
     pprint(shared_perms)
 
 
@@ -158,6 +162,22 @@ def roles_refresh():
     # Move tarball directory to "roles/"
     move_dir = "gcp_iam_update_bot-" + tarball_name
     move_directory(move_dir)
+
+
+def list_perms(list_roles):
+    """
+    Lists permissions for each supplied role.
+
+    Args:
+        list_roles (list): A list of roles
+    """
+
+    # For each role in the list
+    # Find the permissions
+    for role in list_roles:
+        perms_list = get_permissions(role)
+        print(f"# The permissions for {role} are:")
+        pprint(perms_list)
 
 
 def move_directory(move_dir):
@@ -218,7 +238,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Compares GCP IAM roles and outputs analysis.")
     parser.add_argument("-d", "--diff", nargs='+', metavar="ROLES", help="Compares roles and outputs the permissions difference.")
     parser.add_argument("-s", "--shared", nargs='+', metavar="ROLES", help="Compares roles and outputs the shared permissions.")
-    parser.add_argument("-a", "--all", nargs='+', metavar="ROLES", help="Compares roles and outputs the differences and the shared permissinos.")
+    parser.add_argument("-a", "--all", nargs='+', metavar="ROLES", help="Compares roles and outputs the differences and the shared permissins.")
+    parser.add_argument("-l", "--list", nargs='+', metavar="ROLES", help="Lists permissions for role(s).")
     parser.add_argument("-r", "--refresh", help="Refreshes the local \"roles\" folder.", action='store_true')
 
     args = vars(parser.parse_args())
@@ -227,9 +248,9 @@ if __name__ == "__main__":
     if args["refresh"]:
         logging.info("Refresh flag set, will refresh local \"roles\" folder and continue..")
         roles_refresh()
-    
+
     # Require at least one argument
-    if not args["diff"] and not args["shared"] and not args["all"]:
+    if not args["diff"] and not args["shared"] and not args["all"] and not args["list"] :
         logging.error("One argument must be supplied.")
         sys.exit(0)
 
@@ -241,14 +262,14 @@ if __name__ == "__main__":
         logging.debug("Roles folder exists.. proceeding")
     else:
         logging.error("\"roles\" folder does not exist. This is required for analysis.")
-        
+
         # Ask user if they want to dl roles folder
-        refresh = input("Do you want to download the \"roles\" folder now? y/n \n") 
+        refresh = input("Do you want to download the \"roles\" folder now? y/n \n")
         if refresh == "y":
             roles_refresh()
         elif refresh == "n":
             logging.info("\"roles\" folder is required for analysis. Please execute with -r flag.")
         else:
             logging.error(f"Invalid or no input found. Value entered: \"{refresh}\"")
-      
+
     inputs(args)


### PR DESCRIPTION
This PR adds the `--list` functionality which will return / display all permissions for a given role. Example usage:

```
./gcp-iam-analyzer.py -l tpu.xpnAgent
# The permissions for tpu.xpnAgent are:
['compute.addresses.use',
 'compute.firewalls.create',
 'compute.firewalls.delete',
 'compute.firewalls.get',
 'compute.firewalls.update',
 'compute.globalOperations.get',
 'compute.networks.get',
 'compute.networks.list',
 'compute.networks.updatePolicy',
 'compute.networks.use',
 'compute.networks.useExternalIp',
 'compute.routes.list',
 'compute.subnetworks.get',
 'compute.subnetworks.list',
 'compute.subnetworks.use',
 'compute.subnetworks.useExternalIp',
 'compute.zoneOperations.get']
```