### PR TITLE
fixes refresh flow

### DIFF
--- a/gcp-iam-analyzer.py
+++ b/gcp-iam-analyzer.py
@@ -261,6 +261,10 @@ if __name__ == "__main__":
         logging.info(
             "Refresh flag set, will refresh local \"roles\" folder and continue..")
         roles_refresh()
+        print("Roles directory updated. \n")
+        if not args["diff"] and not args["shared"] and not args["all"] and not args["list"]:
+            print("Exiting - no further action requested.")
+            sys.exit(0)
 
     # Require at least one argument
     if not args["diff"] and not args["shared"] and not args["all"] and not args["list"]:


### PR DESCRIPTION
We weren't letting the user know the database was refreshed and instead went right to an error saying no argument was supplied. The database is refreshed, and an argument like `-d` `-s` etc. is required, but we should gracefully handle a scenario where someone only wants to update the roles DB and do nothing else.