### PR TITLE
Multi permission lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You update your local roles database at anytime via `./gcp-iam-analyzer.py -r`.
 
 ### Permissions Analysis
 
-- Can calculate which IAM roles have a specific IAM permission. (`-p` flag)
+- Will calculate which IAM roles have N + 1 IAM permissions. This is useful if you'd like to know which roles share similar permissions. (`-p` flag)
 
 ## Usage
 

--- a/gcp-iam-analyzer.py
+++ b/gcp-iam-analyzer.py
@@ -9,6 +9,7 @@ import sys
 import shutil
 import json
 from pprint import pprint
+import re
 
 
 def inputs(args):
@@ -48,9 +49,13 @@ def inputs(args):
         list_perms(list_roles)
     if args["perm"]:
         logging.info(
-            "Permission flag set, will output all roles which contain the supplied permission. \n")
-        role_permission = str(args["perm"][0])
-        list_roles_for_perm(role_permission)
+            "Permission flag set, will output all roles which contain the supplied permission(s). \n")
+        if len(args["perm"]) == 1:
+            role_permission = str(args["perm"][0])
+            list_roles_for_perm(role_permission)
+        else:
+            for permission in args["perm"]:
+                list_roles_for_perm(permission)
 
 
 def perms_diff(diff_roles):
@@ -226,6 +231,9 @@ def list_roles_for_perm(role_permission):
         logging.error(f"You entered: {role_permission}")
         sys.exit(1)
 
+    # Before finding roles remove special characters other than periods
+    role_permission = format_permission(role_permission)
+
     # Empty list which we will add roles with permission to
     roles_with_perm = []
 
@@ -262,6 +270,20 @@ def permission_validation(role_permission):
     num_periods = role_permission.count(".")
     if num_periods == 2:
         return True
+
+
+def format_permission(role_permission):
+    """
+    Look for commas and remove.
+    This is useful if a user passes in a list of permissions with commas
+
+    Args:
+        role_permission (str): A GCP IAM permission.
+    """
+
+    new_permission = re.sub(r",", "", role_permission)
+
+    return new_permission
 
 
 def get_all_role_names():

--- a/gcp-iam-analyzer.py
+++ b/gcp-iam-analyzer.py
@@ -247,7 +247,7 @@ def list_roles_for_perm(role_permission):
 
     # If there are roles with the specific permission
     if roles_with_perm:
-        print(f"# The roles with the \"{role_permission}\" permission are: \n")
+        print(f"\n # The roles with the \"{role_permission}\" permission are: \n")
         for role in roles_with_perm:
             pprint(role)
     else:


### PR DESCRIPTION
Can now handle N +1  permission lookups via 2 formats:

- `permission, permission`
- `permission permission`

For the 2 permissions `accessapproval.settings.delete accessapproval.serviceAccounts.get` the output will look like:

```
 # The roles with the "accessapproval.settings.delete" permission are: 

'accessapproval.configEditor'
'owner'

 # The roles with the "accessapproval.serviceAccounts.get" permission are: 

'accessapproval.invalidator'
'accessapproval.configEditor'
'owner'
'accessapproval.viewer'
'viewer'
'accessapproval.approver'
'editor'
```